### PR TITLE
fix: allows water threshold to be 0

### DIFF
--- a/src/components/form/TaskForm.js
+++ b/src/components/form/TaskForm.js
@@ -39,6 +39,15 @@ const TaskForm = ({
       id: "task-form",
       defaultValues,
       validate: async (values) => {
+        // The 0 validation error: values.waterThresh is blank at this point
+        // FIX:
+        // gets the value of the 'Water Threshold' element (waterThresholdElementValue)
+        // if the value == 0, then set values.waterThresh = waterThresholdElementValue
+        let waterThresholdElementValue = document.getElementById('Water Threshold');
+        if (waterThresholdElementValue && waterThresholdElementValue.value == 0){
+          values.waterThresh = waterThresholdElementValue.value;
+        };
+
         const errors = await Validate(values, settings, task.name);
         console.log(`Errors are: `, errors);
         return errors;


### PR DESCRIPTION
Added an if statement to check if the water threshold property is in the form and if it is, and its value is being perceived as blank, then it is set to the value from the water threshold element value from the form.