### PR TITLE
fix: add styles to remove up/down arrows on number inputs in the forms

### DIFF
--- a/src/assets/styles/form.scss
+++ b/src/assets/styles/form.scss
@@ -70,3 +70,15 @@ form {
     cursor: pointer;
   }
 }
+
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none !important;
+  margin: 0 !important;
+}
+
+/* Firefox */
+input[type=number] {
+  -moz-appearance: textfield !important; 
+}


### PR DESCRIPTION
Adds styling rules to remove the up/down arrows from the number inputs since they are not required and using these changes the input values in a way that causes an error.